### PR TITLE
chore: add general PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,7 +9,7 @@ title: '(feat|fix|chore|doc): _description of introduced change_'
 Thanks for opening this contribution!
 _What does this PR introduce? Does it fix a bug? Does it add a new feature? Is it enhancing documentation?_
 
-Fixes # (issue)
+Fixes # (issuenumber from PR destination repo)
 
 ## Pre-review checks
 
@@ -24,3 +24,4 @@ Please ensure to do as many of the following checks as possible, before asking f
 - Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
 - Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
 - Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
+- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+---
+name: Pull Request Template
+about: 'template for PRs that ensures basic information is provided'
+title: '(feat|fix|chore|doc): _description of introduced change_'
+---
+
+## Description
+
+Thanks for opening this contribution!
+_What does this PR introduce? Does it fix a bug? Does it add a new feature? Is it enhancing documentation?_
+
+## Pre-review checks
+
+Please ensure to do as many of the following checks as possible, before asking for committer review:
+
+- [ ] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
+- [ ] Copyright and license header are present on all affected files
+
+### Additional information
+
+- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
+- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
+- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
+- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,8 @@ title: '(feat|fix|chore|doc): _description of introduced change_'
 Thanks for opening this contribution!
 _What does this PR introduce? Does it fix a bug? Does it add a new feature? Is it enhancing documentation?_
 
+Fixes # (issue)
+
 ## Pre-review checks
 
 Please ensure to do as many of the following checks as possible, before asking for committer review:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+.idea/


### PR DESCRIPTION
## Description 

This PR introduces an org wide pull request template with a basic structure, that contributors can follow.
Also included is a list of checks, that contributors should complete, before asking committers for review. 
A list with links to further reading and project guidelines is included at the end.

fixes #4 