### PR TITLE
chore(issue-templates): add 3rd party issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/track-3rd-party-ip-issues-template.md
+++ b/.github/ISSUE_TEMPLATE/track-3rd-party-ip-issues-template.md
@@ -1,45 +1,42 @@
 ---
 name: Track 3rd-party dependency IP issues
 about: If you want to track intellectual property issues
-title: ''
-labels: 
-assignees: ''
-
 ---
 
-**Description**  
-We use the following 3rd-party content:  
+## Content Usage and Explaination
+We use the following 3rd-party content:
 <!-- Please describe why you need this content and reference it -->
 
-**Link to our Eclipse Foundation Issue**  
-You can found our 3rd-party IP GitLab Issue here:  
+## IP Issue Link to Track
+You can found our 3rd-party IP GitLab Issue here:
 <!-- Please add your GitLab IP Issue Link -->
 
-**Differences**  
+<!-- Info: The following parts are for knowledge sharing, please remove not needed sections -->
+### Instructions
+- Automatic [Dash Licence Check][sig-infra-licence-check] via GitHub Action from `sig-infra` repository
+- Automatic IP Team Review Requests via the [Dash Tool][DASH Tool]
+- Manual IP Team Review Requests via [IP Issue Creation][ip-issue-creation]
+- [Docs to IP Issues][docs-ip-issues]
 
-| Information                 | Advisory                                | Example                    |
-|-----------------------------|-----------------------------------------|----------------------------|
-| ability to merge            | looks good, was already approved        | `approved, #3435`          |
-| non rejected                | also fine                               | `approved, clearlydefined` |
-| restricted but issue number | ok, but please this **must** be tracked | `restricted, #5922`        |
-| :x: restricted              | you don can't use this library/content  | `restricted`               |
+**Additional Info**
+- [Example GitLab Issue][gitlab-example-ip-issue]
+- [TRG 7.03][TRG-7-03]
+- [TRG 7.04][TRG-7-04]
+- only a committer can create a valid IP Ticket!
 
-**Instructions**
-- Automatic IP Team Review Requests via the [Dash Tool](https://github.com/eclipse/dash-licenses)
-- IP issue for [Code Contributions](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new), choose template "vet-project"
-  - title pattern: project/<project id>/-/<name>/0.0
-  - [more information](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-03)
-  - [Example](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/8097)
-- For PRs: use the link to the PR as source reference!  
-- IP issue for [3rd party content](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new)
-  - choose template "vet-third party":
+| Example                     | Information                                          | Advisory                                                                  |
+|-----------------------------|------------------------------------------------------|---------------------------------------------------------------------------|
+| `approved, #3435`           | :heavy_check_mark: ability to merge                  | looks good, was already approved                                          |
+| `approved, clearlydefined`  | :heavy_check_mark: non rejected                      | also fine                                                                 |
+| `restricted, #5922`         | :heavy_multiplication_x: restricted but issue number | ok, but please this **must** be tracked                                   |
+| `restricted`                | :x: restricted                                       | you don can't use this library/content please create a IP Issue on GitLab |
 
-**Additional Info**  
-- [Docs to IP Issues](https://eclipse-tractusx.github.io/docs/oss/issues#eclipse-gitlab-ip-issue-tracker)
-
-- [Eclipse GitLab IP Issue Tracker](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/?search=automotive.tractusx&sort=created_date&state=opened&first_page_size=20)  
-**IMPORTANT**: only a committer can create a valid IP Ticket!
-
-- [Example GitLab Issue](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5875)
-- [TRG 7.04 Checking other content (fonts, images, ...)](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-other-content-fonts-images-)
-- [Dash tool information](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool)
+<!-- Links -->
+[sig-infra-licence-check]: https://github.com/eclipse-tractusx/sig-infra#check-dependencies-with-dash-licenses
+[DASH Tool]: https://github.com/eclipse/dash-licenses
+[ip-issue-creation]: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new
+[TRG-7-03]: https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-03
+[TRG-7-04]: https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04
+[gitlab-example-ip-issue]: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/8097
+[docs-ip-issues]: https://eclipse-tractusx.github.io/docs/oss/issues#eclipse-gitlab-ip-issue-tracker
+[IP Issue Track Link]: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/?search=automotive.tractusx&sort=created_date&state=opened&first_page_size=20

--- a/.github/ISSUE_TEMPLATE/track-3rd-party-ip-issues-template.md
+++ b/.github/ISSUE_TEMPLATE/track-3rd-party-ip-issues-template.md
@@ -1,0 +1,45 @@
+---
+name: Track 3rd-party dependency IP issues
+about: If you want to track intellectual property issues
+title: ''
+labels: 
+assignees: ''
+
+---
+
+**Description**  
+We use the following 3rd-party content:  
+<!-- Please describe why you need this content and reference it -->
+
+**Link to our Eclipse Foundation Issue**  
+You can found our 3rd-party IP GitLab Issue here:  
+<!-- Please add your GitLab IP Issue Link -->
+
+**Differences**  
+
+| Information                 | Advisory                                | Example                    |
+|-----------------------------|-----------------------------------------|----------------------------|
+| ability to merge            | looks good, was already approved        | `approved, #3435`          |
+| non rejected                | also fine                               | `approved, clearlydefined` |
+| restricted but issue number | ok, but please this **must** be tracked | `restricted, #5922`        |
+| :x: restricted              | you don can't use this library/content  | `restricted`               |
+
+**Instructions**
+- Automatic IP Team Review Requests via the [Dash Tool](https://github.com/eclipse/dash-licenses)
+- IP issue for [Code Contributions](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new), choose template "vet-project"
+  - title pattern: project/<project id>/-/<name>/0.0
+  - [more information](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-03)
+  - [Example](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/8097)
+- For PRs: use the link to the PR as source reference!  
+- IP issue for [3rd party content](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/new)
+  - choose template "vet-third party":
+
+**Additional Info**  
+- [Docs to IP Issues](https://eclipse-tractusx.github.io/docs/oss/issues#eclipse-gitlab-ip-issue-tracker)
+
+- [Eclipse GitLab IP Issue Tracker](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/?search=automotive.tractusx&sort=created_date&state=opened&first_page_size=20)  
+**IMPORTANT**: only a committer can create a valid IP Ticket!
+
+- [Example GitLab Issue](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/5875)
+- [TRG 7.04 Checking other content (fonts, images, ...)](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-other-content-fonts-images-)
+- [Dash tool information](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04#checking-libraries-using-the-eclipse-dash-license-tool)


### PR DESCRIPTION
### Description

- add a suggestion for track gitlab issues with a github issue template

updates eclipse-tractusx/.github#2

#### Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files
