### PR TITLE
chore: create .tractusx metadata

### DIFF
--- a/.tractusx
+++ b/.tractusx
@@ -1,0 +1,25 @@
+###############################################################
+# Copyright (c) 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
+product: ".github"
+leadingRepository: "https://github.com/eclipse-tractusx/.github"
+repoCategory: "support"
+repositories:
+  - name: ".github"
+    usage: ".github"
+    url: "https://github.com/eclipse-tractusx/.github"


### PR DESCRIPTION
PR to add missing .tractusx metadata file.

Updates https://github.com/eclipse-tractusx/sig-infra/issues/287