### PR TITLE
docs(release): updated trg template to latest version 

### DIFF
--- a/.github/ISSUE_TEMPLATE/qg-checklist.md
+++ b/.github/ISSUE_TEMPLATE/qg-checklist.md
@@ -32,6 +32,9 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 1.02](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-2) appropriate install instructions either `INSTALL.md` or in `README.md`
 - [ ] [TRG 1.03](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3) appropriate `CHANGELOG.md`
 - [ ] [TRG 1.04](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-4) editable static files
+- [ ] [TRG 1.05](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-5) architecture docs
+- [ ] [TRG 1.06](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-6) administrator guide
+- [ ] [TRG 1.07](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-7) user manual
 
 #### TRG 2 Git
 
@@ -78,7 +81,7 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 7.04](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-04) IP checks for 3rd party content
 - [ ] [TRG 7.05](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-05) Legal information for distributions
 - [ ] [TRG 7.06](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-06) Legal information for end user content
-- [ ] [TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07) Legal notice for documentation
+- [ ] [TRG 7.07](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-07) Legal notice for documentation (non-code)
 - [ ] [TRG 7.08](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-08) Legal notice for KIT documentation
 
 #### TRG 8 Security
@@ -86,6 +89,9 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 8.02](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-02) Mitigate high and above findings in KICS
 - [ ] [TRG 8.04](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-04) Mitigate high and above findings in Trivy
 - [ ] [TRG 8.03](https://eclipse-tractusx.github.io/docs/release/trg-8/trg-8-03) No secret findings by GitGuardian or TruffleHog
+
+#### TRG 9 UX/UI Styleguide
+- [ ] [TRG 9.01](https://eclipse-tractusx.github.io/docs/release/trg-9/trg-9-01) UI consistency/styleguide for UI
 
 #### Hints
 

--- a/.github/ISSUE_TEMPLATE/qg-checklist.md
+++ b/.github/ISSUE_TEMPLATE/qg-checklist.md
@@ -35,6 +35,7 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 1.05](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-5) architecture docs
 - [ ] [TRG 1.06](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-6) administrator guide
 - [ ] [TRG 1.07](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-7) user manual
+- [ ] [TRG 1.08](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-8) open api docs
 
 #### TRG 2 Git
 

--- a/.github/ISSUE_TEMPLATE/qg-checklist.md
+++ b/.github/ISSUE_TEMPLATE/qg-checklist.md
@@ -32,10 +32,10 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 1.02](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-2) appropriate install instructions either `INSTALL.md` or in `README.md`
 - [ ] [TRG 1.03](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-3) appropriate `CHANGELOG.md`
 - [ ] [TRG 1.04](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-4) editable static files
-- [ ] [TRG 1.05](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-5) architecture docs
-- [ ] [TRG 1.06](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-6) administrator guide
-- [ ] [TRG 1.07](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-7) user manual
-- [ ] [TRG 1.08](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-8) open api docs
+- [ ] [TRG 1.05](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-05) architecture docs
+- [ ] [TRG 1.06](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-06) administrator guide
+- [ ] [TRG 1.07](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-07) user manual
+- [ ] [TRG 1.08](https://eclipse-tractusx.github.io/docs/release/trg-1/trg-1-08) open api docs
 
 #### TRG 2 Git
 
@@ -56,7 +56,7 @@ Release Management Reference Issue: <!-- Note: Add the related product RM issue 
 - [ ] [TRG 4.03](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-03) image has `USER` command and Non Root Container
 - [ ] [TRG 4.05](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-05) released image must be placed in `DockerHub`, remove `GHCR` references
 - [ ] [TRG 4.06](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-06) separate notice file for `DockerHub` has all necessary information
-- [ ] [TRG 4.07] (https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-07) root file system is set to read access by default, but can be overwritten by the user
+- [ ] [TRG 4.07](https://eclipse-tractusx.github.io/docs/release/trg-4/trg-4-07) root file system is set to read access by default, but can be overwritten by the user
 
 #### TRG 5 Helm
 


### PR DESCRIPTION
## Description

### What is new?

#### Added
- Added the new TRG 9.01
- Added the new documentation trgs: TRG 1.05 - TRG 1.08

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
